### PR TITLE
Add badge for dependencies and rearrange code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![dependency status](https://deps.rs/repo/github/mcilloni/greenpass/status.svg)](https://deps.rs/repo/github/mcilloni/greenpass)
+
 # greenpass
 A Rust crate to parse EU Digital Green Certificates for COVID-19, with a simple utility to dump certificates with a well formatted output.
 


### PR DESCRIPTION
Trivial change to rearrange the code so that it matches the order of the information in the certificate. I also added a badge to the Readme to keep track of the dependencies.

I have another pull request to fix the extraction of the KID coming but unfortunately I based it on these changes.