### PR TITLE
Added GitHub actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/cross_compile.yaml
+++ b/.github/workflows/cross_compile.yaml
@@ -1,0 +1,27 @@
+on: [push, pull_request]
+name: Cross-compile
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - aarch64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target=${{ matrix.target }}
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --release --target=${{ matrix.target }}

--- a/.github/workflows/cross_compile.yaml
+++ b/.github/workflows/cross_compile.yaml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
 name: Cross-compile
 jobs:
   build:

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,0 +1,19 @@
+name: Security audit
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  pull_request:
+    branches:
+      - master
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -8,7 +8,7 @@ on:
       - '**/Cargo.lock'
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   security_audit:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![dependency status](https://deps.rs/repo/github/mcilloni/greenpass/status.svg)](https://deps.rs/repo/github/mcilloni/greenpass)
+![Build](https://github.com/mcilloni/greenpass/workflows/Build/badge.svg)
 
 # greenpass
 A Rust crate to parse EU Digital Green Certificates for COVID-19, with a simple utility to dump certificates with a well formatted output.


### PR DESCRIPTION
In order to keep the high quality of the code and get notified about failing test cases, Github Actions can be a good tool. The actions I added automatically do the following:
- build: Build and run the tests when there was a commit on the main branch
- cross-compile: Build and run the tests for the aarch64 architecture when there was a commit on the main branch (I intend to write a GUI application with the library for the Pinephone which has this architecture)
- security-audit: automatically check the code for known vulnerabilities each night