### PR TITLE
Bump version on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "greenpass"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base45",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "greenpass"
 authors = ["Marco Cilloni <m.c.cilloni@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 description = "Rust crate to parse EU Digital Green Certificates for COVID-19"
 repository = "https://github.com/mcilloni/greenpass"
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Crate](https://img.shields.io/crates/v/greenpass.svg)](https://crates.io/crates/greenpass)
 [![dependency status](https://deps.rs/repo/github/mcilloni/greenpass/status.svg)](https://deps.rs/repo/github/mcilloni/greenpass)
 ![Build](https://github.com/mcilloni/greenpass/workflows/Build/badge.svg)
 


### PR DESCRIPTION
Added a badge to be able to quickly switch to crates.io and see the version published. I also increased the version number so you can publish the updated version on Github. The KID fix will be beneficial for people to have and they might not use the Github version.